### PR TITLE
Mark as EOL in favor of org.gnome.Decibels

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "Decibels has entered GNOME Incubator, and is thus renamed to org.gnome.Decibels",
+  "end-of-life-rebase": "org.gnome.Decibels"
+}


### PR DESCRIPTION
The app ID has been changed per GNOME guildelines.

See:
- [GNOME/Incubator/Submission#8](https://gitlab.gnome.org/GNOME/Incubator/Submission/-/issues/8)
- [Teams/Releng/AppOrganization/AppLifecycle.md#coredevelopment-incubation](https://gitlab.gnome.org/Teams/Releng/AppOrganization/-/blob/main/AppLifecycle.md#coredevelopment-incubation)
- [GNOME/Incubator/decibels#70](https://gitlab.gnome.org/GNOME/Incubator/decibels/-/merge_requests/70)
- https://github.com/flathub/flathub/pull/5087

**DO NOT MERGE** until: 
- [x] https://github.com/flathub/flathub/pull/5087 is merged and 
- [x] the [new app listing](https://flathub.org/apps/org.gnome.Decibels) is available on Flathub.